### PR TITLE
Change required meson version to 0.49

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ project (
 
   default_options: ['cpp_std=c++17'],
   license: 'MIT',
-  meson_version: '>= 0.53',
+  meson_version: '>= 0.49',
   version: '0.1.0'
 )
 


### PR DESCRIPTION
Version 0.49 is packaged in Debian 10 and seems to be working fine.